### PR TITLE
Fix broken CirrusWrapperTests.cs

### DIFF
--- a/Cirrus.Tests/UnitTests/CirrusWrapperTests.cs
+++ b/Cirrus.Tests/UnitTests/CirrusWrapperTests.cs
@@ -24,7 +24,7 @@ namespace Cirrus.Tests.UnitTests
             _cirrusRestWrapperMock = new Mock<ICirrusRestWrapper>();
             _loggerMock = new Mock<ILogger>();
 
-            var mockCirrusWrapper = new Mock<CirrusWrapper>();
+            var mockCirrusWrapper = new Mock<ICirrusWrapper>();
             mockCirrusWrapper.Setup(mock => mock.FetchDeviceHistory(1, false, true, 288, CancellationToken.None));
 
             


### PR DESCRIPTION
A runtime failure occurs during `dotnet test` because the interface needs to be mocked instead of the sealed public class.